### PR TITLE
Update code to download model files from artifactory

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,13 @@
+version: "1"
+rules:                      
+  - base: master           
+    upstream: explosion:master
+    mergeMethod: merge
+    mergeUnstable: false
+    assignees:              # Optional
+      - rolzy-rio
+    reviewers:              # Optional
+      - rolzy-rio
+    conflictReviewers:      # Optional, on merge conflict assign a reviewer
+      - rolzy-rio
+conflictLabel: "merge-conflict"  # Optional, on merge conflict assign a custom label, Default: merge-conflict

--- a/spacy/about.py
+++ b/spacy/about.py
@@ -1,5 +1,5 @@
 # fmt: off
 __title__ = "spacy"
 __version__ = "3.7.6"
-__download_url__ = "https://github.com/explosion/spacy-models/releases/download"
+__download_url__ = "https://artifactory.riotinto.com/artifactory/spacy-models"
 __compatibility__ = "https://raw.githubusercontent.com/explosion/spacy-models/master/compatibility.json"

--- a/spacy/cli/download.py
+++ b/spacy/cli/download.py
@@ -169,6 +169,10 @@ def download_model(
     if not base_url.endswith("/"):
         base_url = about.__download_url__ + "/"
     download_url = urljoin(base_url, filename)
+
+    msg.info(f"You are using the Rio Tinto fork of spaCy.")
+    msg.info(f"Downloading model from {download_url}")
+
     if not download_url.startswith(about.__download_url__):
         raise ValueError(f"Download from {filename} rejected. Was it a relative path?")
     pip_args = list(user_pip_args) if user_pip_args is not None else []


### PR DESCRIPTION
Changing the download URL to point to Artifactory

## Description
This change will let `python -m spacy download` command to download models from Artifactory
